### PR TITLE
Updated atvi to battlenet per updated tracker gg api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Discord bot for calculating aggregate player stats for Call of Duty Warzone.
   - Warzone Rumble: `rmbl`
   - Plunder: `plndr`
   - Resurgence: `rsg`
-- Supports PlayStation Network (`psn`), Xbox Live (`xbl`) and Activision (`atvi`) platforms
+- Supports PlayStation Network (`psn`), Xbox Live (`xbl`) and Battlenet (`battlenet`) platforms
 - Supports `[time]` parameter to only show stats from specific times, e.g., last 8 hours (`8h`) or past 3 days (`3d`). Default value: `24h`
   - Hours: `h`
   - Days: `d`
@@ -39,7 +39,7 @@ Discord bot for calculating aggregate player stats for Call of Duty Warzone.
 ## Issues
 - If you encounter issues with your profile not loading, check if you can access it on the [COD Warzone Stats Tracker Site](https://cod.tracker.gg/warzone) whose awesome API is used by the bot. Yours might be set to private.
 - Allow the bot permission to use external emojis so it can use icons for platforms instead.
-- For Activision, it may be necessary to suffix the hash for your profile when requesting stats (e.g., `username#12345`).
+- For Battlenet, it may be necessary to suffix the hash for your profile when requesting stats (e.g., `username#12345`).
 - Feel free to open a GitHub issue if you face any problems.
 
 ## Credits

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,5 @@
 export type GameMode = 'br' | 'rmbl' | 'plndr' | 'rsg';
-export type Platform = 'psn' | 'xbl' | 'atvi';
+export type Platform = 'psn' | 'xbl' | 'battlenet';
 
 export type Player = {
     playerId: string;

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -54,7 +54,7 @@ async function postHelp(message: Message) {
     str.push(...[
         'Parameters: `<required>`, `[optional]`',
         'modeId: `br` Battle Royale, `rmbl` Rumble, `plndr` Plunder, `rsg` Resurgence',
-        'platformId: `psn` PlayStation, `xbl` Xbox, `atvi` Activision',
+        'platformId: `psn` PlayStation, `xbl` Xbox, `battlenet` Battlenet',
         'duration: `h` hours, `d` days, `w` weeks, `m` months. Defaults to `24h`.'
     ]);
     

--- a/src/controller/mapping.ts
+++ b/src/controller/mapping.ts
@@ -9,10 +9,10 @@ export default new Map<string, Command>([
         regex: [
             /^!wz stats (?<modeId>br|rmbl|plndr|rsg)$/,
             /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<duration>[0-9]+[h|d|w|m])$/,
-            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|atvi) (?<playerId>[0-9A-Za-z#_\-]+)$/,
-            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|atvi) (?<playerId>[0-9A-Za-z#_\-]+) (?<duration>[0-9]+[h|d|w|m])$/,
-            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|atvi) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
-            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|atvi) "(?<playerId>[0-9A-Za-z#_\- ]+)" (?<duration>[0-9]+[h|d|w|m])$/,
+            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|battlenet) (?<playerId>[0-9A-Za-z#_\-]+)$/,
+            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|battlenet) (?<playerId>[0-9A-Za-z#_\-]+) (?<duration>[0-9]+[h|d|w|m])$/,
+            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|battlenet) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
+            /^!wz stats (?<modeId>br|rmbl|plndr|rsg) (?<platformId>psn|xbl|battlenet) "(?<playerId>[0-9A-Za-z#_\- ]+)" (?<duration>[0-9]+[h|d|w|m])$/,
         ]
     }],
     ['players', {
@@ -26,8 +26,8 @@ export default new Map<string, Command>([
         usage: '!wz register <platformId> "<playerId>"' ,
         help: 'Register a new player',
         regex: [
-            /^!wz register (?<platformId>psn|xbl|atvi) (?<playerId>[0-9A-Za-z#_\-]+)$/,
-            /^!wz register (?<platformId>psn|xbl|atvi) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
+            /^!wz register (?<platformId>psn|xbl|battlenet) (?<playerId>[0-9A-Za-z#_\-]+)$/,
+            /^!wz register (?<platformId>psn|xbl|battlenet) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
         ]
     }],
     ['unregister', {
@@ -35,8 +35,8 @@ export default new Map<string, Command>([
         usage: '!wz unregister <platformId> "<playerId>"', 
         help: 'Unregister a player',
         regex: [
-            /^!wz unregister (?<platformId>psn|xbl|atvi) (?<playerId>[0-9A-Za-z#_\-]+)$/,
-            /^!wz unregister (?<platformId>psn|xbl|atvi) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
+            /^!wz unregister (?<platformId>psn|xbl|battlenet) (?<playerId>[0-9A-Za-z#_\-]+)$/,
+            /^!wz unregister (?<platformId>psn|xbl|battlenet) "(?<playerId>[0-9A-Za-z#_\- ]+)"$/,
         ] 
     }],
     ['schedule', {

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -72,7 +72,7 @@ export function formatDuration(s: number) {
 
 export function formatPlayername(player: Player, client: Client = null) {
 
-    let platformNames = { "psn" : "PlayStation" , "xbl" : "Xbox" , "atvi" : "Activision"};
+    let platformNames = { "psn" : "PlayStation" , "xbl" : "Xbox" , "battlenet" : "Battlenet"};
     let { playerId, platformId } = player;
     
     // remove unique id from playerId


### PR DESCRIPTION
After attempting to install and use the bot. It seems the Tracker API URL has been updated to use `battlenet` instead of `atvi`. This PR updates the references.

Updated: https://api.tracker.gg/api/v2/warzone/standard/profile/battlenet/vDis%231749
OLD: https://api.tracker.gg/api/v2/warzone/standard/profile/atvi/vDis%231749